### PR TITLE
Support file uploads

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -32,6 +32,7 @@ Route::prefix(config('private-api.route'))
                                         Route::get('/', [Controllers\AssetsController::class, 'index']);
                                         Route::get('{id}', [Controllers\AssetsController::class, 'show']);
                                         Route::delete('{id}', [Controllers\AssetsController::class, 'destroy']);
+                                        Route::post('/', [Controllers\AssetsController::class, 'store']);
                                     });
                             });
                     });

--- a/src/Http/Controllers/AssetsController.php
+++ b/src/Http/Controllers/AssetsController.php
@@ -3,6 +3,8 @@
 namespace Tv2regionerne\StatamicPrivateApi\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Statamic\Facades;
 use Statamic\Http\Controllers\API\ApiController;
@@ -36,6 +38,28 @@ class AssetsController extends ApiController
         }
 
         return AssetResource::make($asset);
+    }
+    
+    public function store(Request $request, $container)
+    {
+        $request->merge([
+            'container' => $container,
+        ]);
+        
+        if ($file = $request->input('file_url')) {
+            $contents = file_get_contents($file);
+            
+            if (! $contents) {
+                abort(406);    
+            }
+            
+            $filename = Str::afterLast($file, '/');
+            Storage::disk('local')->put('tmp/'.$filename, $contents);
+            
+            $request->files->set('file', new UploadedFile(storage_path('tmp/'.$filename), $filename));            
+        }
+
+        return (new CpController($request))->store($request);
     }
 
     public function destroy(Request $request, $container, $id)


### PR DESCRIPTION
@SylvesterDamgaard is this the approach you were hoping for?

Its a POST to the asset container end point, requiring a `folder` input field.
If a `file` is in the request it will try to upload it, otherwise if a `file_url` is there it will download the file from that url and add it as an uploaded file.

