### PR TITLE
Update local disk path for asset upload

### DIFF
--- a/src/Http/Controllers/AssetsController.php
+++ b/src/Http/Controllers/AssetsController.php
@@ -60,7 +60,8 @@ class AssetsController extends ApiController
             $filename = Str::afterLast($file, '/');
             Storage::disk('local')->put('tmp/'.$filename, $contents);
 
-            $request->files->set('file', new UploadedFile(storage_path('tmp/'.$filename), $filename));
+            $filepath = config('filesystems.disks.local.root').'/tmp/';
+            $request->files->set('file', new UploadedFile($filepath.$filename, $filename));
         }
 
         try {


### PR DESCRIPTION
Hi!

The temporary files are written to the local Disk.
If the `root` of the local disk is set a subfolder (i.e.: `app`), then the upload will fail as `storage_path('tmp/')` returns `/storage/tmp/` but not `/storage/**app**/tmp`.