### PR TITLE
Fix issues with asset uploading by url and validation handling of metadata

### DIFF
--- a/src/Http/Controllers/AssetsController.php
+++ b/src/Http/Controllers/AssetsController.php
@@ -5,10 +5,8 @@ namespace Tv2regionerne\StatamicPrivateApi\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Http\Testing\MimeType;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
-use League\MimeTypeDetection\MimeTypeDetector;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Facades;
 use Statamic\Facades\Asset;
@@ -62,7 +60,7 @@ class AssetsController extends ApiController
 
             $tmpFilename = Str::afterLast(parse_url($file, PHP_URL_PATH), '/');
             if (empty($tmpFilename)) {
-                $tmpFilename = 'default_' . uniqid();
+                $tmpFilename = 'default_'.uniqid();
             }
 
             // Get filename from reuest
@@ -101,7 +99,6 @@ class AssetsController extends ApiController
 
             $fields->validate();
 
-
             $values = $fields->process()->values()->merge([
                 'focus' => $request->focus,
             ]);
@@ -122,6 +119,7 @@ class AssetsController extends ApiController
             if (isset($asset)) {
                 $asset->delete();
             }
+
             return $this->returnValidationErrors($e);
         }
     }
@@ -182,14 +180,15 @@ class AssetsController extends ApiController
         return Str::after($id, '::');
     }
 
-    private  function sanitizeFilename($filename, $extension = null)
+    private function sanitizeFilename($filename, $extension = null)
     {
         $pathinfo = pathinfo($filename);
 
         $filename = Str::slug(Str::limit($pathinfo['filename'], 100, ''), '-');
         if ($extension ??= $pathinfo['extension'] ?? null) {
-            $filename .= '.' . $extension;
+            $filename .= '.'.$extension;
         }
+
         return $filename;
     }
 }

--- a/src/Http/Controllers/GlobalVariablesController.php
+++ b/src/Http/Controllers/GlobalVariablesController.php
@@ -42,7 +42,6 @@ class GlobalVariablesController extends ApiController
                 $values = $values->only($request->input('_localized'));
             }
 
-
             $set->data($values);
 
             $set->globalSet()->addLocalization($set)->save();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -85,7 +85,7 @@ abstract class TestCase extends OrchestraTestCase
         foreach ($configs as $config) {
             $app['config']->set(
                 "statamic.$config",
-                require (__DIR__."/../vendor/statamic/cms/config/{$config}.php")
+                require(__DIR__."/../vendor/statamic/cms/config/{$config}.php")
             );
         }
 
@@ -97,7 +97,7 @@ abstract class TestCase extends OrchestraTestCase
             'directory' => __DIR__.'/__fixtures__/users',
         ]);
 
-        $app['config']->set('private-api', require (__DIR__.'/../config/private-api.php'));
+        $app['config']->set('private-api', require(__DIR__.'/../config/private-api.php'));
         $app['config']->set('private-api.enabled', true);
         $app['config']->set('private-api.middleware', 'web');
         $app['config']->set('private-api.resources', [


### PR DESCRIPTION
This PR will handle missing or invalid file extensions in the URL.
The filename will also be sanitized.
It's possible to pass a filename parameter to set the filename during upload by URL.
Fixes #20 