### PR TITLE
Fix filtering on private api routes

### DIFF
--- a/src/Http/Controllers/UsersController.php
+++ b/src/Http/Controllers/UsersController.php
@@ -15,9 +15,11 @@ class UsersController extends ApiController
 {
     use VerifiesPrivateAPI;
 
+    protected $resourceConfigKey = 'users';
+
     public function index()
     {
-        abort_if(! $this->resourcesAllowed('users', ''), 404);
+        abort_if(! $this->resourcesAllowed($this->resourceConfigKey, ''), 404);
 
         $this->authorize('view', [User::class]);
 
@@ -28,7 +30,7 @@ class UsersController extends ApiController
 
     public function show($id)
     {
-        abort_if(! $this->resourcesAllowed('users', ''), 404);
+        abort_if(! $this->resourcesAllowed($this->resourceConfigKey, ''), 404);
 
         if (! $user = Facades\User::find($id)) {
             abort(404);
@@ -58,7 +60,7 @@ class UsersController extends ApiController
 
     public function update(Request $request, $id)
     {
-        abort_if(! $this->resourcesAllowed('users', ''), 404);
+        abort_if(! $this->resourcesAllowed($this->resourceConfigKey, ''), 404);
 
         if (! $user = Facades\User::find($id)) {
             abort(404);
@@ -81,7 +83,7 @@ class UsersController extends ApiController
 
     public function destroy(Request $request, $id)
     {
-        abort_if(! $this->resourcesAllowed('users', ''), 404);
+        abort_if(! $this->resourcesAllowed($this->resourceConfigKey, ''), 404);
 
         if (! $user = Facades\User::find($id)) {
             abort(404);


### PR DESCRIPTION
Currently filtering does not work because none of the controllers implement the required allowedFilters method:
https://github.com/statamic/cms/blob/5.x/src/Http/Controllers/API/ApiController.php#L132-L134

Which means all filters are just discarded.

This PR adds in a simplified version of Statamic core's method:
https://github.com/statamic/cms/blob/5.x/src/Http/Controllers/API/UsersController.php#L39-L44

to the VerifiesPrivateAPI trait.

---

To enable filtering one can follow the steps outlined in the Statamic docs - https://statamic.dev/rest-api#enabling-filters
But make the changes specified to the `config/private-api.php` file instead of `config/statamic/api.php`

---

Setting this to draft as I plan to implement this for all the controllers unless that is not desired.